### PR TITLE
add getLedger method

### DIFF
--- a/ctapi/ctapi.py
+++ b/ctapi/ctapi.py
@@ -237,3 +237,19 @@ class CTAPI(object):
         params.update(args)
 
         return self._api_query('getGains', params)
+
+   
+    #
+    # getLedger
+    #
+    def getLedger(self, **args):
+        """
+        Used to get Returns your Ledger
+        """
+
+        params = {
+            'show_advanced': '1',
+        }
+        params.update(args)
+
+        return self._api_query('getLedger', params)


### PR DESCRIPTION
Extending the ctapi to include getLedger API call as supported by Cointracking.info API docs.  Defaults to show_advanced=1 (true) and allows all other supported args to be supplied be caller.  Found this useful to get income information for use/conversion into Quicken...